### PR TITLE
don't colorize comment or string

### DIFF
--- a/lib/bracket-matcher.js
+++ b/lib/bracket-matcher.js
@@ -9,14 +9,14 @@ export default class BracketMatcher {
   }
 
   cleanUp() {
-    this.decorations = this.myEditor.getDecorations({ stamp: 'bczr' });
+    this.decorations = this.myEditor.getDecorations({stamp: 'bczr'});
     this.decorations.forEach(dec => dec.destroy());
   }
 }
 
 function colorify(symbol_start, symbol_end) {
   let count = 0;
-  const regex = new RegExp('\\'+symbol_start+'|'+'\\'+symbol_end, 'g');
+  const regex = new RegExp(`\\${symbol_start}|\\${symbol_end}`, 'g');
   const editor = atom.workspace.getActiveTextEditor();
 
   editor.scan(regex, (result) => {
@@ -25,23 +25,24 @@ function colorify(symbol_start, symbol_end) {
       return;
     }
 
-    if(result.matchText == symbol_start) {
-      count ++;
+    if (result.matchText === symbol_start) {
+      count++;
     }
 
-    marker = editor.markBufferRange(result.range);
-    colorClass = 'color'+count;
+    const marker = editor.markBufferRange(result.range);
+    const colorClass = `color${count}`;
 
-    decoration = editor.decorateMarker(
-      marker, { type: 'text', class: colorClass, stamp:'bczr' }
+    editor.decorateMarker(
+      marker, {type: 'text', class: colorClass, stamp: 'bczr'}
     );
 
-    if(result.matchText == symbol_end)
-    {
-      count --;
+    if (result.matchText === symbol_end) {
+      count--;
     }
 
-    if( count < 0) count = 0;
+    if (count < 0) {
+      count = 0;
+    }
 
   });
 }

--- a/lib/bracket-matcher.js
+++ b/lib/bracket-matcher.js
@@ -16,18 +16,23 @@ export default class BracketMatcher {
 
 function colorify(symbol_start, symbol_end) {
   let count = 0;
-  regex = new RegExp('\\'+symbol_start+'|'+'\\'+symbol_end, 'g');
+  const regex = new RegExp('\\'+symbol_start+'|'+'\\'+symbol_end, 'g');
+  const editor = atom.workspace.getActiveTextEditor();
 
-  atom.workspace.getActiveTextEditor().scan(regex, (result) => {
+  editor.scan(regex, (result) => {
+
+    if (isRangeCommentedOrString(editor, result.range)) {
+      return;
+    }
 
     if(result.matchText == symbol_start) {
       count ++;
     }
 
-    marker = atom.workspace.getActiveTextEditor().markBufferRange(result.range);
+    marker = editor.markBufferRange(result.range);
     colorClass = 'color'+count;
 
-    decoration = atom.workspace.getActiveTextEditor().decorateMarker(
+    decoration = editor.decorateMarker(
       marker, { type: 'text', class: colorClass, stamp:'bczr' }
     );
 
@@ -39,4 +44,18 @@ function colorify(symbol_start, symbol_end) {
     if( count < 0) count = 0;
 
   });
+}
+
+function isRangeCommentedOrString(editor, range) {
+  const scopesArray = editor.scopeDescriptorForBufferPosition(range.start).getScopesArray();
+  for (let scope of scopesArray.reverse()) {
+    scope = scope.split('.');
+    if (scope.includes('embedded') && scope.includes('source')) {
+      return false;
+    }
+    if (scope.includes('comment') || scope.includes('string')) {
+      return true;
+    }
+  }
+  return false;
 }


### PR DESCRIPTION
This will ignore brackets that are in comments or strings

I copied [atom/bracket-matcher](https://github.com/atom/bracket-matcher/blob/f4511d6cf4849a92ce3437204e537b32c0f54fab/lib/bracket-matcher-view.coffee#L326-L335)

fixes #3 
