### PR TITLE
Colored text

### DIFF
--- a/lib/bracket-colorizer.js
+++ b/lib/bracket-colorizer.js
@@ -4,13 +4,12 @@ import { CompositeDisposable } from 'atom';
 import BracketMatcher from './bracket-matcher';
 
 export default {
-
   subscriptions: null,
 
   config: {
     brackets: {
       title: 'Brackets to match',
-      description: "The format should be, '{symbol_start};{symbol_end}'",
+      description: "The format should be, '{symbol_start};{symbol_end}'test",
       default: ['{;}', '(;)', '[;]'],
       type: 'array',
       items: {
@@ -68,7 +67,11 @@ export default {
     if(editor.changeSubscription != null) {
       editor.changeSubscription.dispose();
     }
+    if(editor.tokenizeSubscription != null) {
+      editor.tokenizeSubscription.dispose();
+    }
     editor.changeSubscription = editor.onDidStopChanging(() => process(editor));
+    editor.tokenizeSubscription = editor.onDidTokenize(() => process(editor));
     process(editor);
   },
 
@@ -82,6 +85,9 @@ export default {
 
       if(element.changeSubscription != null) {
         element.changeSubscription.dispose();
+      }
+      if(editor.tokenizeSubscription != null) {
+        editor.tokenizeSubscription.dispose();
       }
     });
   }

--- a/lib/bracket-colorizer.js
+++ b/lib/bracket-colorizer.js
@@ -4,12 +4,13 @@ import { CompositeDisposable } from 'atom';
 import BracketMatcher from './bracket-matcher';
 
 export default {
+
   subscriptions: null,
 
   config: {
     brackets: {
       title: 'Brackets to match',
-      description: "The format should be, '{symbol_start};{symbol_end}'test",
+      description: "The format should be, '{symbol_start};{symbol_end}'",
       default: ['{;}', '(;)', '[;]'],
       type: 'array',
       items: {

--- a/lib/bracket-matcher.js
+++ b/lib/bracket-matcher.js
@@ -29,7 +29,7 @@ function colorify(symbol_start, symbol_end) {
       count++;
     }
 
-    const marker = editor.markBufferRange(result.range);
+    const marker = editor.markBufferRange(result.range, {invalidate: 'inside'});
     const colorClass = `color${count}`;
 
     editor.decorateMarker(


### PR DESCRIPTION
I fixed colored brackets in comments/strings before a file is tokenized

and fixed colored text when entered before or after markers

Before this PR:

![before](https://user-images.githubusercontent.com/97994/38625697-ac1d64e4-3d70-11e8-898c-3bb55862c532.gif)

After:

![after](https://user-images.githubusercontent.com/97994/38625705-af70a804-3d70-11e8-9d95-12a28429fff8.gif)
